### PR TITLE
Refactor to use Boolean instead of integer in the connector.

### DIFF
--- a/src/main/java/com/admios/connector/watsonalchemylanguage/WatsonAlchemyLanguageConnector.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/WatsonAlchemyLanguageConnector.java
@@ -71,7 +71,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @param quotations Set this to 1 to include quotations that are linked to detected entities
 	 * @param sentiment Set this to 1 to analyze the sentiment towards each detected entity. This incurs an additional
 	 *            transaction charge
-	 * @param showSourceText Set this to 1 to include the source text in the response
+	 * @param showSourceText Check this to include the source text in the response
 	 * @param structuredEntities Set this to 0 to ignore structured entities, such as Quantity, EmailAddress,
 	 *            TwitterHandle, Hashtag, and IPAddress
 	 * @param cquery A visual constraints query to apply to the web page. Required when sourceText is set to cquery
@@ -84,7 +84,7 @@ public class WatsonAlchemyLanguageConnector {
 	public Entities entities(String source, @Optional Integer maxRetrieve,
 			@Optional Integer coreference, @Optional Integer disambiguate, @Optional Integer knowledgeGraph,
 			@Optional Integer linkedData, @Optional Integer quotations, @Optional Integer sentiment,
-			@Optional Integer showSourceText, @Optional Integer structuredEntities,
+			@Optional Boolean showSourceText, @Optional Integer structuredEntities,
 			@Optional String cquery, @Optional String xpath, @Optional String sourceText) {
 
 		return new EntitiesHandler(config.getService(), source)
@@ -104,11 +104,11 @@ public class WatsonAlchemyLanguageConnector {
 	 * @param source The text, html or url to process.
 	 * @param anchorDate The date to use as "today" when interpreting phrases in the text like "next tuesday." Format:
 	 *            <code>yyyy-mm-dd hh:mm:ss</code>
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * @return return {@link Dates}
 	 */
 	@Processor
-	public Dates dateExtraction(String source, @Optional String anchorDate, @Optional Integer showSourceText) {
+	public Dates dateExtraction(String source, @Optional String anchorDate, @Optional Boolean showSourceText) {
 		return new DateExtractionHandler(config.getService(), source)
 				.addAnchorDate(anchorDate)
 				.addShowSourceText(showSourceText)
@@ -143,7 +143,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @param knowledgeGraph Set this to 1 to include knowledge graph information in the results. This incurs an
 	 *            additional transaction charge
 	 * @param linkedData Set this to 0 to hide Linked Data content links in the response
-	 * @param showSourceText Set this to 1 to include the source text in the response TwitterHandle, Hashtag, and
+	 * @param showSourceText Check this to include the source text in the response TwitterHandle, Hashtag, and
 	 *            IPAddress
 	 * @param cquery A visual constraints query to apply to the web page. Required when sourceText is set to cquery
 	 * @param xpath An XPath query to apply to the web page. Required when sourceText is set to one of the XPath values
@@ -154,7 +154,7 @@ public class WatsonAlchemyLanguageConnector {
 	@Processor
 	public Concepts concepts(String source, @Optional Integer maxRetrieve,
 			@Optional Integer knowledgeGraph, @Optional Integer linkedData,
-			@Optional Integer showSourceText, @Optional String cquery,
+			@Optional Boolean showSourceText, @Optional String cquery,
 			@Optional String xpath, @Optional String sourceText) {
 
 		return new ConceptsHandler(config.getService(), source).addMaxRetrieve(maxRetrieve)
@@ -182,7 +182,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @param source The text, HTML or URL to process.
 	 * @param target Target phrase. The service will return sentiment information for the phrase that is found
 	 *            in the source text.
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * @param cquery A visual constraints query to apply to the web page. Required when <code>sourceText</code> is set
 	 *            to cquery.
 	 * @param xpath An XPath query to apply to the web page. Required when <code>sourceText</code> is set to one of the
@@ -192,7 +192,7 @@ public class WatsonAlchemyLanguageConnector {
 	 */
 	@Processor
 	public DocumentSentiment targetedSentiment(String source, String target, 
-			@Optional Integer showSourceText, @Optional String cquery,
+			@Optional Boolean showSourceText, @Optional String cquery,
 			@Optional String xpath, @Optional String sourceText) {
 		return new TargetedSentimentHandler(config.getService(), source)
 				.addCquery(cquery)
@@ -214,7 +214,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @param maxRetrieve Maximum number of entities to return (default = 50) detected entities by default).
 	 * @param knowledgeGraph Set this to 1 to include knowledge graph information in the results.
 	 * @param sentiment Set this to 1 to analyze the sentiment towards each detected entity.
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * @param cquery A visual constraints query to apply to the web page. Required when <code>sourceText</code> is set
 	 *            to cquery.
 	 * @param xpath An XPath query to apply to the web page. Required when <code>sourceText</code> is set to one of the
@@ -225,7 +225,7 @@ public class WatsonAlchemyLanguageConnector {
 	@Processor
 	public Keywords keywords(String source, @Optional Integer maxRetrieve,
 			@Optional Integer knowledgeGraph, @Optional Integer sentiment,
-			@Optional Integer showSourceText, @Optional String cquery,
+			@Optional Boolean showSourceText, @Optional String cquery,
 			@Optional String xpath, @Optional String sourceText) {
 		return new KeywordsHandler(config.getService(), source)
 				.addCquery(cquery)
@@ -245,11 +245,11 @@ public class WatsonAlchemyLanguageConnector {
 	 * {@sample.xml ../../../doc/watson-alchemy-language-connector.xml.sample watson-alchemy-language:microformats}
 	 *
 	 * @param source The text, html or url to process.
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * @return return {@link Microformats}
 	 */
 	@Processor
-	public Microformats microformats(String source, @Optional Integer showSourceText) {
+	public Microformats microformats(String source, @Optional Boolean showSourceText) {
 		return new MicroformatsHandler(config.getService(), source).addShowSourceText(showSourceText).execute();
 	}
 
@@ -276,7 +276,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * {@sample.xml ../../../doc/watson-alchemy-language-connector.xml.sample watson-alchemy-language:sentimentAnalysis}
 	 *
 	 * @param source The text, HTML document or url to process
-	 * @param showSourceText Set this to 1 to include the source text in the response
+	 * @param showSourceText Check this to include the source text in the response
 	 * @param cquery A visual constraints query to apply to the web page. Required when sourceText is set to cquery
 	 * @param xpath An XPath query to apply to the web page. Required when sourceText is set to one of the XPath values
 	 * @param sourceText How to obtain the source text from the webpage
@@ -284,7 +284,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @return return {@link DocumentSentiment}
 	 */
 	@Processor
-	public DocumentSentiment sentimentAnalysis(String source, @Optional Integer showSourceText, @Optional String cquery,
+	public DocumentSentiment sentimentAnalysis(String source, @Optional Boolean showSourceText, @Optional String cquery,
 			@Optional String xpath, @Optional String sourceText) {
 		return new SentimentAnalysisHandler(config.getService(), source).addShowSourceText(showSourceText)
 				.addCquery(cquery).addXpath(xpath).addSourceText(sourceText).execute();
@@ -299,12 +299,12 @@ public class WatsonAlchemyLanguageConnector {
 	 *
 	 * @param source The text, HTML document or url to process
 	 * @param model The unique alphanumeric identifier for your custom model
-	 * @param showSourceText Set this to 1 to include the source text in the response
+	 * @param showSourceText Check this to include the source text in the response
 	 * 
 	 * @return return {@link TypedRelations}
 	 */
 	@Processor
-	public TypedRelations typedRelations(String source, @Optional String model, @Optional Integer showSourceText) {
+	public TypedRelations typedRelations(String source, @Optional String model, @Optional Boolean showSourceText) {
 		return new TypedRelationsHandler(config.getService(), source).addModel(model)
 				.addShowSourceText(showSourceText).execute();
 	}
@@ -317,7 +317,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * {@sample.xml ../../../doc/watson-alchemy-language-connector.xml.sample watson-alchemy-language:languageDetection}
 	 *
 	 * @param source The text, HTML or URL to process.
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * @param cquery A visual constraints query to apply to the web page. Required when <code>sourceText</code> is set
 	 *            to cquery.
 	 * @param xpath An XPath query to apply to the web page. Required when <code>sourceText</code> is set to one of the
@@ -327,7 +327,7 @@ public class WatsonAlchemyLanguageConnector {
 	 * @return return {@link Language}
 	 */
 	@Processor
-	public Language languageDetection(String source, @Optional Integer showSourceText, @Optional String cquery,
+	public Language languageDetection(String source, @Optional Boolean showSourceText, @Optional String cquery,
 			@Optional String xpath, @Optional String sourceText) {
 		return new LanguageDetectionHandler(config.getService(), source)
 				.addShowSourceText(showSourceText)
@@ -345,12 +345,12 @@ public class WatsonAlchemyLanguageConnector {
 	 * {@sample.xml ../../../doc/watson-alchemy-language-connector.xml.sample watson-alchemy-language:titleExtraction}
 	 *
 	 * @param source The HTML or URL to process.
-	 * @param showSourceText Set this to 1 to include the source text in the response.
+	 * @param showSourceText Check this to include the source text in the response.
 	 * 
 	 * @return return {@link DocumentTitle}
 	 */
 	@Processor
-	public DocumentTitle titleExtraction(String source, @Optional Integer showSourceText) {
+	public DocumentTitle titleExtraction(String source, @Optional Boolean showSourceText) {
 		return new TitleExtractionHandler(config.getService(), source)
 				.addShowSourceText(showSourceText)
 				.execute();

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/handler/URLCommonHandler.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/handler/URLCommonHandler.java
@@ -1,5 +1,7 @@
 package com.admios.connector.watsonalchemylanguage.handler;
 
+import static com.admios.connector.watsonalchemylanguage.util.Utils.intValue;
+
 import com.admios.connector.watsonalchemylanguage.util.StringUtils;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
 
@@ -10,8 +12,8 @@ public abstract class URLCommonHandler<HandlerClass, result> extends CommonHandl
 	}
 
 	@SuppressWarnings("unchecked")
-	public HandlerClass addShowSourceText(Integer showSourceText) {
-		return (HandlerClass) addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, showSourceText);
+	public HandlerClass addShowSourceText(Boolean showSourceText) {
+		return (HandlerClass) addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, intValue(showSourceText));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/DateExtractionHandler.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/DateExtractionHandler.java
@@ -1,5 +1,6 @@
 package com.admios.connector.watsonalchemylanguage.handler.implementation;
 
+import static com.admios.connector.watsonalchemylanguage.util.Utils.intValue;
 import com.admios.connector.watsonalchemylanguage.handler.CommonHandler;
 import com.admios.connector.watsonalchemylanguage.util.StringUtils;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
@@ -15,8 +16,8 @@ public class DateExtractionHandler extends CommonHandler<Dates> {
 		return addParam(AlchemyLanguage.ANCHOR_DATE, query);
 	}
 	
-	public DateExtractionHandler addShowSourceText(Integer number) {
-		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, number);
+	public DateExtractionHandler addShowSourceText(Boolean number) {
+		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, intValue(number));
 	}
 
 	@Override

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/MicroformatsHandler.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/MicroformatsHandler.java
@@ -3,6 +3,7 @@
  */
 package com.admios.connector.watsonalchemylanguage.handler.implementation;
 
+import static com.admios.connector.watsonalchemylanguage.util.Utils.intValue;
 import com.admios.connector.watsonalchemylanguage.handler.CommonHandler;
 import com.admios.connector.watsonalchemylanguage.util.StringUtils;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
@@ -18,8 +19,8 @@ public class MicroformatsHandler extends CommonHandler<Microformats> {
 		super(service, StringUtils.getHtmlOrUrlType(text), text);
 	}
 	
-	public MicroformatsHandler addShowSourceText(Integer number) {
-		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, number);
+	public MicroformatsHandler addShowSourceText(Boolean number) {
+		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, intValue(number));
 	}
 	
 	@Override

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/TitleExtractionHandler.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/TitleExtractionHandler.java
@@ -1,5 +1,6 @@
 package com.admios.connector.watsonalchemylanguage.handler.implementation;
 
+import static com.admios.connector.watsonalchemylanguage.util.Utils.intValue;
 import com.admios.connector.watsonalchemylanguage.handler.CommonHandler;
 import com.admios.connector.watsonalchemylanguage.util.StringUtils;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
@@ -12,8 +13,8 @@ public class TitleExtractionHandler extends CommonHandler<DocumentTitle> {
 		super(service, StringUtils.getHtmlOrUrlType(source), source);
 	}
 
-	public TitleExtractionHandler addShowSourceText(Integer showSourceText) {
-		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, showSourceText);
+	public TitleExtractionHandler addShowSourceText(Boolean showSourceText) {
+		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, intValue(showSourceText));
 	}
 
 	@Override

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/TypedRelationsHandler.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/handler/implementation/TypedRelationsHandler.java
@@ -1,5 +1,6 @@
 package com.admios.connector.watsonalchemylanguage.handler.implementation;
 
+import static com.admios.connector.watsonalchemylanguage.util.Utils.intValue;
 import com.admios.connector.watsonalchemylanguage.handler.CommonHandler;
 import com.admios.connector.watsonalchemylanguage.util.StringUtils;
 import com.ibm.watson.developer_cloud.alchemy.v1.AlchemyLanguage;
@@ -16,8 +17,8 @@ public class TypedRelationsHandler extends CommonHandler<TypedRelations> {
 		return addParam(AlchemyLanguage.MODEL_ID, model);
 	}
 
-	public TypedRelationsHandler addShowSourceText(Integer showSourceText) {
-		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, showSourceText);
+	public TypedRelationsHandler addShowSourceText(Boolean showSourceText) {
+		return addParam(AlchemyLanguage.SHOW_SOURCE_TEXT, intValue(showSourceText));
 	}
 
 	@Override

--- a/src/main/java/com/admios/connector/watsonalchemylanguage/util/Utils.java
+++ b/src/main/java/com/admios/connector/watsonalchemylanguage/util/Utils.java
@@ -1,0 +1,9 @@
+package com.admios.connector.watsonalchemylanguage.util;
+
+public class Utils {
+
+	public static Integer intValue(Boolean bool){
+		if (bool == null) return null;
+		return bool? 1: 0;
+	}
+}

--- a/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/DateExtractionTestCase.java
+++ b/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/DateExtractionTestCase.java
@@ -29,7 +29,7 @@ public class DateExtractionTestCase extends AbstractTestCase<WatsonAlchemyLangua
 	
 	@Test
 	public void getDatesUsingHTML() {
-		Dates dates = getConnector().dateExtraction("<html><body><h1>Finally found it!!!</h1><p>The Person was found alive on November 10, 2014 in Marsella.</p><p>The last time was on a party was October 31, 2014 at a ranch outside the City Lights.</p></body></html>", null, 1);
+		Dates dates = getConnector().dateExtraction("<html><body><h1>Finally found it!!!</h1><p>The Person was found alive on November 10, 2014 in Marsella.</p><p>The last time was on a party was October 31, 2014 at a ranch outside the City Lights.</p></body></html>", null, true);
 		
 		assertNotNull(dates);
 		assertEquals("english", dates.getLanguage());

--- a/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/KeywordsTestCase.java
+++ b/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/KeywordsTestCase.java
@@ -24,7 +24,7 @@ public class KeywordsTestCase extends AbstractTestCase<WatsonAlchemyLanguageConn
 				+ " from the huge fields of the Cooper and Surat Basins in the arid lands out near the"
 				+ " Queensland, New South Wales and South Australian borders.";
 		
-		Keywords results = getConnector().keywords(paragraph, null, null, null, 0, null, null, null);
+		Keywords results = getConnector().keywords(paragraph, null, null, null, false, null, null, null);
 		
 		assertNotNull(results);
 		assertEquals("english", results.getLanguage());

--- a/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/TargetedSentimentTestCase.java
+++ b/src/test/java/com/admios/connector/watsonalchemylanguage/automation/functional/TargetedSentimentTestCase.java
@@ -19,7 +19,7 @@ public class TargetedSentimentTestCase extends AbstractTestCase<WatsonAlchemyLan
 	public void getTargetedSentimentUsingText(){
 		
 		String paragraph = "The polymer is very good but node is very bad";
-		DocumentSentiment results = getConnector().targetedSentiment(paragraph, "polymer", 1, null, null, null);
+		DocumentSentiment results = getConnector().targetedSentiment(paragraph, "polymer", true, null, null, null);
 		
 		assertNotNull(results);
 		assertEquals("english", results.getLanguage());
@@ -27,7 +27,7 @@ public class TargetedSentimentTestCase extends AbstractTestCase<WatsonAlchemyLan
 		assertNotNull(results.getSentiment().getScore());
 		assertEquals("POSITIVE", results.getSentiment().getType().toString());
 		
-		results = getConnector().targetedSentiment(paragraph, "node", 1, null, null, null);
+		results = getConnector().targetedSentiment(paragraph, "node", true, null, null, null);
 		assertNotNull(results);
 		assertEquals("english", results.getLanguage());
 		assertEquals(1, results.getTotalTransactions().intValue());

--- a/src/test/java/com/admios/connector/watsonalchemylanguage/util/UtilsTestCase.java
+++ b/src/test/java/com/admios/connector/watsonalchemylanguage/util/UtilsTestCase.java
@@ -1,0 +1,17 @@
+package com.admios.connector.watsonalchemylanguage.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UtilsTestCase {
+
+	@Test
+	public void intValueTest(){
+		
+		assertEquals(null, Utils.intValue(null));
+		assertEquals(0, Utils.intValue(false).intValue());
+		assertEquals(1, Utils.intValue(true).intValue());
+		
+	}
+}


### PR DESCRIPTION
Refactor the method _addShowSourceText()_ to accept a **Boolean** instead a **Integer.** In this way the form in AnyPoint Studio will show a check box which is more intuitive for the end user.

A small test was added to show the behavior of the new method _intValue()_.
